### PR TITLE
Delete rule for related entities 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Although primarily in-memory, SwiftletModel’s data model is Codable, allowing 
   * [Model Definitions](#model-definitions)
 - [How to Save Entities](#how-to-save-entities)
 - [How to Delete Entities](#how-to-delete-entities)
-  * [How to cascade delete](#how-to-cascade-delete)
+  * [Relationship DeleteRule](#relationship-deleterule)
 - [How to Query Entities](#how-to-query-entities)
   * [Query with nested models](#query-with-nested-models)
   * [Related models query](#related-models-query)
@@ -219,22 +219,22 @@ chat.delete(from: &context)
 
 Calling `delete(...)` will 
 - remove the current instance from the context
-- it will nullify all relations
+- it will nullify all relations or cascade delete depending on `DeleteRule` attribute
 - call `willDelete(...)` and `didDelete(...)` callbacks when needed.
 
-### How to cascade delete
+### Relationship DeleteRule
 
-There is a `willDelete(...)` callback that can be utilized for cascade deletion implementation:
+DeleteRule allows to specify how the related entities would be treated when current entity is deleted:
+- nullify (the default option)
+- cascade 
 
 ```swift
-extension Message {
-    func willDelete(from context: inout Context) throws {
-        try delete(\.$attachment, inverse: \.$message, from: &context)
-    }
-}
+
+@Relationship(deleteRule: .cascade, inverse: \.message)
+var attachment: Attachment?
+
 ```
-The method is throwing to be able to perform some additional checks before deletion 
-and throw an error if something has gone wrong.
+
 
 ## How to Query Entities
 

--- a/Sources/SwiftletModel/Relationship/RelationTypes.swift
+++ b/Sources/SwiftletModel/Relationship/RelationTypes.swift
@@ -40,6 +40,13 @@ public typealias ToManyRelation<T: EntityModelProtocol,
 
 public enum Relations { }
 
+public extension Relations {
+    enum DeleteRule {
+        case cascade
+        case nullify
+    }
+}
+
 //MARK: - Directionality
 
 public protocol DirectionalityProtocol { }

--- a/Sources/SwiftletModel/Relationship/Relationship.swift
+++ b/Sources/SwiftletModel/Relationship/Relationship.swift
@@ -39,7 +39,8 @@ public extension Relationship where Directionality == Relations.Mutual,
                                     Constraints == Relations.Optional,
                                     Cardinality == Relations.ToOne<Entity> {
 
-    init<EnclosingType>(inverse: KeyPath<Entity, EnclosingType?>) {
+    init<EnclosingType>(deleteRule: Relations.DeleteRule = .nullify,
+                        inverse: KeyPath<Entity, EnclosingType?>) {
         self.init(relation: .none)
     }
 }
@@ -48,6 +49,7 @@ public extension Relationship where Directionality == Relations.Mutual,
                                     Cardinality == Relations.ToOne<Entity> {
 
     init<EnclosingType>(_ constraint: Constraint<Constraints>, 
+                        deleteRule: Relations.DeleteRule = .nullify,
                         inverse: KeyPath<Entity, EnclosingType?>) {
         self.init(relation: .none)
     }
@@ -57,7 +59,8 @@ public extension Relationship where Directionality == Relations.Mutual,
                                     Constraints == Relations.Required,
                                     Cardinality == Relations.ToMany<Entity> {
 
-    init<EnclosingType>(inverse: KeyPath<Entity, EnclosingType?>) {
+    init<EnclosingType>(deleteRule: Relations.DeleteRule = .nullify,
+                        inverse: KeyPath<Entity, EnclosingType?>) {
         self.init(relation: .none)
     }
 }
@@ -77,7 +80,8 @@ public extension Relationship where Directionality == Relations.OneWay,
 public extension Relationship where Directionality == Relations.OneWay,
                                     Cardinality == Relations.ToOne<Entity> {
 
-    init(_ constraint: Constraint<Constraints> = .optional) {
+    init(_ constraint: Constraint<Constraints> = .optional,
+         deleteRule: Relations.DeleteRule = .nullify) {
         self.init(relation: .none)
     }
 }
@@ -86,7 +90,7 @@ public extension Relationship where Directionality == Relations.OneWay,
                                     Cardinality == Relations.ToMany<Entity>,
                                     Constraints == Relations.Required {
 
-    init() {
+    init(deleteRule: Relations.DeleteRule = .nullify) {
         self.init(relation: .none)
     }
 

--- a/Sources/SwiftletModelMacros/RelationshipAttributes.swift
+++ b/Sources/SwiftletModelMacros/RelationshipAttributes.swift
@@ -19,20 +19,42 @@ struct RelationshipAttributes {
     let relationWrapperType: WrapperType
     let propertyName: String
     let keyPathAttributes: KeyPathAttributes
+    let deleteRule: DeleteRuleAttribute
 }
 
 extension RelationshipAttributes {
+   
     enum WrapperType: String, CaseIterable {
         case relationship = "Relationship"
         
         var title: String {
             rawValue
         }
-        
-        static let allCasesTitleSet: Set<String> = {
-            Set(Self.allCases.map { $0.title })
-        }()
     }
+    
+     enum DeleteRuleAttribute: String, CaseIterable {
+         static let deleteRule = "deleteRule"
+         
+         case cascade
+         case nullify
+         
+         init?(_ expressionString: String) {
+             let value = Self.allCases.first { expressionString.contains($0.rawValue) }
+             guard let value else {
+                 return nil
+             }
+             
+             self = value
+         }
+         
+         init(labeledExprListSyntax: LabeledExprListSyntax) {
+             self = labeledExprListSyntax
+                 .filter { $0.labelString?.contains(DeleteRuleAttribute.deleteRule) ?? false }
+                 .compactMap { DeleteRuleAttribute($0.expressionString) }
+                 .first ?? .nullify
+         }
+     }
+     
     
     enum KeyPathAttributes {
         case labeledExpressionList(String)

--- a/Tests/SwiftletModelTests/Models/Message.swift
+++ b/Tests/SwiftletModelTests/Models/Message.swift
@@ -19,7 +19,7 @@ struct Message: Codable, Sendable {
     @Relationship(inverse: \.messages)
     var chat: Chat?
 
-    @Relationship(inverse: \.message)
+    @Relationship(deleteRule: .cascade, inverse: \.message)
     var attachment: Attachment?
 
     @Relationship(inverse: \.replyTo)
@@ -30,10 +30,6 @@ struct Message: Codable, Sendable {
 
     @Relationship
     var viewedBy: [User]? = nil
-
-    func willDelete(from context: inout Context) throws {
-        try delete(\.$attachment, inverse: \.$message, from: &context)
-    }
 }
 
 extension Query where Entity == Message {


### PR DESCRIPTION
New feature allowing to specify delete rule: cascade or nullify for `Relationship`