### PR TITLE
Patch merge strategy fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,7 +1260,7 @@ try user.save(to: &context)
 
 Fragment merge strategy patches existing models in the context. 
 In other words, it updates only non-nil values. 
-It's automatically generated via macro so you don't have to do anything.
+It's automatically generated for all mutable nullable properties via macro so you don't have to do anything.
 
 
 ```swift

--- a/Sources/SwiftletModelMacros/EntityModelMacro/Attributes/PropertyAttributes.swift
+++ b/Sources/SwiftletModelMacros/EntityModelMacro/Attributes/PropertyAttributes.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct PropertyAttributes {
     let propertyName: String
+    let isMutable: Bool
 }

--- a/Sources/SwiftletModelMacros/EntityModelMacro/EntityModelMacro.swift
+++ b/Sources/SwiftletModelMacros/EntityModelMacro/EntityModelMacro.swift
@@ -549,6 +549,7 @@ private extension VariableDeclSyntax {
             return nil
         }
 
+        let isMutable = bindingSpecifier.tokenKind == .keyword(.var)
         for binding in bindings {
             guard let propertyName = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
                   let typeAnnotation = binding.typeAnnotation?.type else {
@@ -560,7 +561,7 @@ private extension VariableDeclSyntax {
                 continue
             }
 
-            return PropertyAttributes(propertyName: propertyName)
+            return PropertyAttributes(propertyName: propertyName, isMutable: isMutable)
 
         }
         return nil


### PR DESCRIPTION
Patch merge strategy fix: generate patch merge strategy only for mutable optional properties

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track property mutability and generate `patch` merge strategy entries only for mutable optional properties.
> 
> - **EntityModel macro**:
>   - `VariableDeclSyntax.patch(...)`: filters to `.filter { $0.isMutable }` so only mutable optional properties are included in `MergeStrategy`.
> - **Attributes**:
>   - `PropertyAttributes`: add `isMutable`.
>   - `VariableDeclSyntax.optionalPropertiesAttributes()` and `staticPropertiesAttributes()`: detect mutability (`var`) and populate `PropertyAttributes(isMutable:)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0ddbbfd8d5824b721ce5b30b290d0ddbfd7eecc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->